### PR TITLE
Add check_years_mode_consistency

### DIFF
--- a/hypatia/backend/ModelSettings.py
+++ b/hypatia/backend/ModelSettings.py
@@ -58,6 +58,7 @@ class ModelSettings:
         self._validate_regional_settings()
 
     def _validate_global_settings(self):
+        check_years_mode_consistency(self.mode, self.years)
         for table_name, table in self.global_settings.items():
             check_table_name(
                 file_name="global",

--- a/hypatia/backend/tests/ModelSettingsTests.py
+++ b/hypatia/backend/tests/ModelSettingsTests.py
@@ -49,7 +49,7 @@ class TestModelSettings(unittest.TestCase):
             self.multi_node.regional_settings,
         )
 
-    def test_multi_node_planning_operation(self):
+    def test_multi_node_operation_settings(self):
         ModelSettings(
             ModelMode.Operation,
             self.multi_node.global_settings,

--- a/hypatia/backend/tests/ModelSettingsTests.py
+++ b/hypatia/backend/tests/ModelSettingsTests.py
@@ -25,15 +25,31 @@ class TestModelSettings(unittest.TestCase):
 
     Test the ModelSettings initialization logic
     """
-    def test_create_technology_columns(self):
-        # single node
+    def test_single_node_planning_settings(self):
         ModelSettings(
             ModelMode.Planning,
             self.single_node.global_settings,
             self.single_node.regional_settings,
         )
 
-        # multi node
+    def test_single_node_operation_settings(self):
+        self.assertRaises(
+            hypatiaException.WrongNumberOfYears,
+            lambda: ModelSettings(
+                ModelMode.Operation,
+                self.single_node.global_settings,
+                self.single_node.regional_settings,
+            )
+        )
+
+    def test_multi_node_planning_settings(self):
+        ModelSettings(
+            ModelMode.Planning,
+            self.multi_node.global_settings,
+            self.multi_node.regional_settings,
+        )
+
+    def test_multi_node_planning_operation(self):
         ModelSettings(
             ModelMode.Operation,
             self.multi_node.global_settings,
@@ -666,7 +682,7 @@ class TestModelSettings(unittest.TestCase):
         )
 
         #timesteps not define
-        global_settings = copy.deepcopy(self.single_node.global_settings)
+        global_settings = copy.deepcopy(self.multi_node.global_settings)
         global_settings.pop('Timesteps', None)
         model_settings = ModelSettings(
             ModelMode.Operation,
@@ -698,7 +714,7 @@ class TestModelSettings(unittest.TestCase):
         self.assertTrue(np.array_equal(expected, model_settings.timeslice_fraction))
 
         #timesteps not define
-        global_settings = copy.deepcopy(self.single_node.global_settings)
+        global_settings = copy.deepcopy(self.multi_node.global_settings)
         global_settings.pop('Timesteps', None)
         model_settings = ModelSettings(
             ModelMode.Operation,

--- a/hypatia/error_log/Checks.py
+++ b/hypatia/error_log/Checks.py
@@ -18,6 +18,7 @@ from hypatia.error_log.Exceptions import (
     WrongCarrierType,
     WrongNumberOfYears,
 )
+from hypatia.utility.constants import ModelMode
 
 
 def check_index(index, table_name, file_name, allowed_indices):
@@ -73,7 +74,7 @@ def check_table_name(
 
 def check_sheet_name(path, file_name, ids):
 
-    """Checks if the sheets in the parameter files have valid names when 
+    """Checks if the sheets in the parameter files have valid names when
     reading the data
     """
 
@@ -176,7 +177,7 @@ def check_years_mode_consistency(mode, main_years):
     mode
     """
 
-    if mode == "Operation":
+    if mode == ModelMode.Operation:
 
         if len(main_years) != 1:
 


### PR DESCRIPTION
## TLDR
In #13 I removed the check called check_years_mode_consistency by mistake. 
This change adds it back. 

## TESTS
Unit tests
(venv) afa@afa-mbp Hypatia % git add hypatia/backend/tests/ModelSettingsTests.py