### PR TITLE
allowing the model to chose among multiple size for each connection

### DIFF
--- a/hypatia/backend/StrData.py
+++ b/hypatia/backend/StrData.py
@@ -31,7 +31,7 @@ from hypatia.utility.constants import (
     technology_categories,
     carrier_types,
 )
-from hypatia.utility.constants import (list_connection_operation, list_connection_planning,
+from hypatia.utility.constants import (list_connection,
  take_regional_sheets, take_trade_ids, take_ids, take_global_ids)
 
 from hypatia.utility.utility import vicenty
@@ -154,6 +154,7 @@ class ReadSets:
         # read the possible connections
         
         if len(self.regions) > 1: 
+            self.sizes = list(self.glob_mapping["Connection_sizes"]["Size_name"])
             self.trade_line = {}
             
             for carr in glob_mapping["Carriers_glob"]["Carrier"]:
@@ -386,11 +387,6 @@ class ReadSets:
             )
 
             self.connection_sheet_ids = {
-                "F_OM": {
-                    "value": 0,
-                    "index": pd.Index(self.main_years, name="Years"),
-                    "columns": indexer,
-                },
                 "V_OM": {
                     "value": 0,
                     "index": pd.Index(self.main_years, name="Years"),
@@ -426,6 +422,16 @@ class ReadSets:
                     "columns": indexer,
                 },
             }
+            
+            
+            for size in self.sizes:
+                
+                self.connection_sheet_ids.update(
+                    {"F_OM_{}".format(size): {
+                        "value": 0,
+                        "index": pd.Index(self.main_years, name="Years"),
+                        "columns": indexer,
+                    }})
 
             self.global_sheet_ids = {
                 "Max_production_global": {
@@ -462,7 +468,8 @@ class ReadSets:
                     "columns": ["Global Emission Cap"],
                 },
             }
-
+            
+            list_connection_operation = list_connection(mode = "Operation", sizes = self.sizes)
             connections_operation_sorted = sorted(self.connection_sheet_ids.items(), key=lambda pair: list_connection_operation.index(pair[0]))
             self.connection_sheet_ids_sorted = dict(connections_operation_sorted)
 
@@ -470,16 +477,6 @@ class ReadSets:
 
                 self.connection_sheet_ids.update(
                     {
-                        "INV": {
-                            "value": 0,
-                            "index": pd.Index(self.main_years, name="Years"),
-                            "columns": indexer,
-                        },
-                        "Min_lumpycap": {
-                            "value": 0,
-                            "index": pd.Index(self.main_years, name="Years"),
-                            "columns": indexer,
-                        },
                         "Decom_cost": {
                             "value": 0,
                             "index": pd.Index(self.main_years, name="Years"),
@@ -528,6 +525,28 @@ class ReadSets:
                         },
                     }
                 )
+                
+                for size in self.sizes:
+                    
+                    self.connection_sheet_ids.update(
+                        {
+                            "F_OM_{}".format(size): {
+                                "value": 0,
+                                "index": pd.Index(self.main_years, name="Years"),
+                                "columns": indexer,
+                                },
+                            "INV_{}".format(size): {
+                            "value": 0,
+                            "index": pd.Index(self.main_years, name="Years"),
+                            "columns": indexer,
+                        },
+                        "Min_integer_cap_{}".format(size): {
+                            "value": 0,
+                            "index": pd.Index(self.main_years, name="Years"),
+                            "columns": indexer,
+                        }})
+                    
+                list_connection_planning = list_connection(mode = "Planning", sizes = self.sizes)   
                 connections_planning_sorted = sorted(self.connection_sheet_ids.items(), key=lambda pair: list_connection_planning.index(pair[0]))
                 self.connection_sheet_ids_sorted = dict(connections_planning_sorted)
 
@@ -1060,7 +1079,7 @@ class ReadSets:
 
         if len(self.regions) > 1:
 
-            trade_data_ids = take_trade_ids(mode=self.mode)
+            trade_data_ids = take_trade_ids(mode=self.mode,sizes=self.sizes)
             global_data_ids = take_global_ids(mode=self.mode)
             check_sheet_name(path, "parameters_connections", trade_data_ids)
             check_sheet_name(path, "parameters_global", global_data_ids)

--- a/hypatia/utility/constants.py
+++ b/hypatia/utility/constants.py
@@ -6,13 +6,43 @@ parameter filese
 
 # Sorted connection parameter sheets
 
-list_connection_operation = ["V_OM","F_OM","Line_efficiency",
-"AnnualProd_perunit_capacity","Residual_capacity","Capacity_factor_line","Line_length"]
+def list_connection(mode,sizes):
+    
+    if mode == "Operation":
+        
+        list_connection = ["V_OM", "Line_efficiency",
+                           "AnnualProd_perunit_capacity", "Residual_capacity", "Capacity_factor_line", "Line_length"]
+        
+        for size in sizes:
+            
+            list_connection.append("F_OM_{}".format(size)
+                )
+            
+    
+    if mode == "Planning":
+        
+        list_connection = ["V_OM","Decom_cost",
+        "Line_Economic_life","Interest_rate","Line_lifetime","Line_efficiency",
+        "AnnualProd_perunit_capacity","Residual_capacity","Capacity_factor_line",
+        "Line_length","Min_newcap","Max_newcap","Min_totalcap","Max_totalcap"]
+            
+        
+        for size in sizes:
+            
+            list_connection.append("F_OM_{}".format(size))
+            list_connection.append("INV_{}".format(size))
+            list_connection.append("Min_integer_cap_{}".format(size))
+                             
+            
+    return list_connection
+            
+# list_connection_operation = ["V_OM","F_OM","Line_efficiency",
+# "AnnualProd_perunit_capacity","Residual_capacity","Capacity_factor_line","Line_length"]
 
-list_connection_planning = ["V_OM","F_OM","INV","Decom_cost",
-"Line_Economic_life","Interest_rate","Line_lifetime","Line_efficiency",
-"AnnualProd_perunit_capacity","Residual_capacity","Capacity_factor_line",
-"Line_length","Min_lumpycap","Min_newcap","Max_newcap","Min_totalcap","Max_totalcap"]
+# list_connection_planning = ["V_OM","F_OM","INV","Decom_cost",
+# "Line_Economic_life","Interest_rate","Line_lifetime","Line_efficiency",
+# "AnnualProd_perunit_capacity","Residual_capacity","Capacity_factor_line",
+# "Line_length","Min_integer_cap","Min_newcap","Max_newcap","Min_totalcap","Max_totalcap"]
 
 
 # Sorted regional parameter sheets
@@ -77,14 +107,13 @@ def take_regional_sheets(mode,technologies,regions):
 
 # Constants of connections data
 
-def take_trade_ids(mode):
+def take_trade_ids(mode,sizes):
     """
     Creates a dictionary for storing the information of the parameter sheets of 
     inter-regional link data based on the given mode
     """
 
     trade_data_ids = {
-        "line_fixed_cost": {"sheet_name": "F_OM", "index_col": 0, "header": [0, 1]},
         "line_var_cost": {"sheet_name": "V_OM", "index_col": 0, "header": [0, 1]},
         "line_residual_cap": {
             "sheet_name": "Residual_capacity",
@@ -109,16 +138,17 @@ def take_trade_ids(mode):
             "header": [0, 1],
         },
     }
+    
+    for size in sizes:
+        
+        trade_data_ids.update(
+            {"line_fixed_cost_{}".format(size): {"sheet_name": "F_OM_{}".format(size), "index_col": 0, "header": [0, 1]}
+                })
 
     if mode == "Planning":
 
         trade_data_ids.update(
-            {
-                "line_inv": {"sheet_name": "INV", "index_col": 0, "header": [0, 1]},
-            
-                "line_lumpycap" : {"sheet_name": "Min_lumpycap", "index_col": 0, "header": [0,1]},
-                
-                "line_decom_cost": {
+            {"line_decom_cost": {
                     "sheet_name": "Decom_cost",
                     "index_col": 0,
                     "header": [0, 1],
@@ -160,6 +190,13 @@ def take_trade_ids(mode):
                 },
             }
         )
+        
+        for size in sizes:
+            
+            trade_data_ids.update({"line_inv_{}".format(size): {"sheet_name": "INV_{}".format(size), "index_col": 0, "header": [0, 1]},
+                        
+                            "line_integer_cap_{}".format(size) : {"sheet_name": "Min_integer_cap_{}".format(size), "index_col": 0, "header": [0,1]},
+                })
 
     return trade_data_ids
 
@@ -472,7 +509,8 @@ global_set_ids = {
     "Carriers_glob": ["Carrier", "Carr_name", "Carr_type", "Carr_unit"],
     "Technologies_glob": ["Technology", "Tech_name", "Tech_category",
     "Tech_cap_unit", "Tech_act_unit"],
-    "Emissions": ["Emission", "Emission_name", "Emission_unit"]
+    "Emissions": ["Emission", "Emission_name", "Emission_unit"],
+    "Connection_sizes": ["Size_number", "Size_name"]
 }
 
 

--- a/hypatia/utility/utility.py
+++ b/hypatia/utility/utility.py
@@ -20,8 +20,7 @@ def stack(a, b, axis=0):
         return cp.vstack([a, b])
     elif axis == 1:
         return cp.hstack([a, b])
-
-
+                
 def newcap_accumulated(newcap, techs, main_years, tlft,period_step):
 
     """
@@ -103,13 +102,13 @@ def _calc_production_overall(
     return production_overall
 
 
-def line_newcap_accumulated(line_lumpy_inv, line_cap, carriers, main_years, line_tlft, period_step):
+def line_newcap_accumulated(line_newcap, carriers, main_years, line_tlft, period_step):
 
     """
     Calculates the accumulated new capacity of each inter-regional link in each 
     year the model horizon based on the useful technical lifetime
     """
-    line_newcap = cp.multiply(line_lumpy_inv,line_cap) # we need to check if this woon't give us a size error (one-row vector multiplied to the matrix)
+    #line_newcap = cp.multiply(line_lumpy_inv,line_cap) # we need to check if this woon't give us a size error (one-row vector multiplied to the matrix)
     index_line = pd.MultiIndex.from_product([carriers, main_years])
     exist_line = pd.DataFrame(0, index=index_line, columns=index_line)
 
@@ -132,6 +131,38 @@ def line_newcap_accumulated(line_lumpy_inv, line_cap, carriers, main_years, line
     )
 
     return line_newcap_accumulated
+
+
+def line_newcap_lump_accumulated(line_newcap_lump, carriers, main_years, line_tlft, period_step):
+
+    """
+    Calculates the accumulated new capacity of each inter-regional link in each 
+    year the model horizon based on the useful technical lifetime
+    """
+    #line_newcap = cp.multiply(line_lumpy_inv,line_cap) # we need to check if this woon't give us a size error (one-row vector multiplied to the matrix)
+    index_line = pd.MultiIndex.from_product([carriers, main_years])
+    exist_line = pd.DataFrame(0, index=index_line, columns=index_line)
+
+    line_newcap_lump_reshape = cp.reshape(line_newcap_lump, (len(main_years) * len(carriers), 1))
+
+    for carrier in carriers:
+        for year in main_years:
+            for year0 in main_years:
+
+                age = (main_years.index(year) - main_years.index(year0))*period_step
+
+                if age >= 0 and age < line_tlft[carrier].values:
+
+                    exist_line.loc[(carrier, year), (carrier, year0)] = 1
+
+    line_newacp_lump_accumulated_reshape = exist_line.values @ line_newcap_lump_reshape
+
+    line_newcap_lump_accumulated = cp.reshape(
+        line_newacp_lump_accumulated_reshape, line_newcap_lump.shape
+    )
+
+    return line_newcap_lump_accumulated
+
 
 
 def decomcap(newcap, techs, main_years, tlft, period_step):
@@ -162,14 +193,13 @@ def decomcap(newcap, techs, main_years, tlft, period_step):
     return decomcap
 
 
-def line_decomcap(line_lumpy_inv, line_cap, carriers, main_years, line_tlft, period_step):
+def line_decomcap(line_newcap, carriers, main_years, line_tlft, period_step):
 
     """
     Calculates the annual decomissioned capacity of each inter-regional link in each
     year of the time horizon based on life time of the new capacities 
     installed in the vintage years
     """
-    line_newcap = cp.multiply(line_lumpy_inv,line_cap)
     index_line = pd.MultiIndex.from_product([carriers, main_years])
     decom_matrix_line = pd.DataFrame(0, index=index_line, columns=index_line)
     line_newcap_reshape = cp.reshape(line_newcap, (len(main_years) * len(carriers), 1))

--- a/test.py
+++ b/test.py
@@ -7,17 +7,17 @@ Created on Mon Mar  6 11:37:41 2023
 
 from hypatia import Model,Plotter, Sensitivity
 #%%
-milp_test = Model(
-    path = 'test/connection_MILP/sets', 
+offshore_test = Model(
+    path = 'test/yeees/central_offshore/sets', 
     mode = 'Planning', period_step = 15)
 #%%
-##milp_test.create_data_excels(path = 'test/connection_MILP/parameters')
+#offshore_test.create_data_excels(path = 'test/yeees/central_offshore/parameters_update')
 #%%
-milp_test.read_input_data(
-    path = 'test/connection_MILP/parameters'
+offshore_test.read_input_data(
+    path = 'test/yeees/central_offshore/parameters'
 )
 #%%
-milp_test.run(solver = "gurobi", verbosity= True)
+offshore_test.run(solver = "gurobi", verbosity= True, force_rewrite=True, Method=3)
 #%%
-milp_test.to_csv(path="test/connection_MILP/results")
+offshore_test.to_csv(path="test/yeees/central_offshore/results")
 #%%


### PR DESCRIPTION
Users can give the model the options of sizes for the inter-regional connections in the "global.xlsx" file. All the inter-regional parameters are defined for each given size. the "line_newcapacity" variable is a boolean variable and is defined for each size type, year, and traded carrier among the regions:

- Build.py: 1) modifying the line new capacity variable to a boolean type 2) Adding the "line_integer_size" constraint to make sure that the model will install only one size for each connection in each modelling year of the horizon 3) Modifying the cost functions based on the new type of variables

- StrData.py: 1) Reading the size options from set files
2) Modifying the parameter sheets

- constants.py: modifying the parameter sheets

- utility.py: Modifying the accumulated new capacity function for the connections